### PR TITLE
Adds AddressLine property to AddressType

### DIFF
--- a/Ubl-Tr/Common/CommonAggregateComponents/AddressType.cs
+++ b/Ubl-Tr/Common/CommonAggregateComponents/AddressType.cs
@@ -34,6 +34,8 @@ namespace UblTr.Common
 
         private CountryType countryField;
 
+        private AddressLineType[] addressLineField;
+
         /// <remarks/>
         [System.Xml.Serialization.XmlElementAttribute(Namespace = "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2")]
         public IDType ID
@@ -212,6 +214,19 @@ namespace UblTr.Common
             set
             {
                 this.countryField = value;
+            }
+        }
+
+        [System.Xml.Serialization.XmlElementAttribute(Namespace = "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2")]
+        public AddressLineType[] AddressLine
+        {
+            get
+            {
+                return this.addressLineField;
+            }
+            set
+            {
+                this.addressLineField = value;
             }
         }
     }


### PR DESCRIPTION
Adds the `AddressLine` property to the `AddressType` class.

This allows for the inclusion of multiple address lines within an address, providing more detailed address information.

Close #102 